### PR TITLE
user timer expiration

### DIFF
--- a/znc.tcl
+++ b/znc.tcl
@@ -207,7 +207,7 @@ if { $scriptdebug } {
 ### Bot Commands --------------------------------------------------------------
 
 proc znc:request { nick host handle chan text } {
-	global scriptCommandPrefix zncPasswordSecurityLevel zncPasswordLength zncnetworkname zncDefaultUserModules zncDefaultNetworkModules
+	global scriptCommandPrefix zncPasswordSecurityLevel zncPasswordLength zncnetworkname zncDefaultUserModules zncDefaultNetworkModules usePreconfiguredNetworks
 	set username [lindex $text 0]
 	set email [lindex $text 1]
 	set networkname [lindex $text 2]

--- a/znc.tcl
+++ b/znc.tcl
@@ -261,7 +261,7 @@ proc znc:confirm {nick host handle chan text} {
 		znc:blockuser:unblock $username 
 		chattr $username -C
 		puthelp "NOTICE $nick :$username is now confirmed."
-	} elseif { validuser $username } {
+	} elseif [ validuser $username ] {
 		puthelp "NOTICE $nick :$username is already confirmed."
 	} else {
 		puthelp "NOTICE $nick :$username does not exist"
@@ -278,7 +278,7 @@ proc znc:deny {nick host handle chan text} {
 		znc:controlpanel:DelUser $username 
 		deluser $username
 		puthelp "NOTICE $nick :$username is now denied."
-	} elseif { validuser $username } {
+	} elseif [ validuser $username ] {
 		puthelp "NOTICE $nick :$username is already confirmed. Use \"${scriptCommandPrefix}DelUser <username>\" to remove"
 	} else {
 		puthelp "NOTICE $nick :$username does not exist"


### PR DESCRIPTION
need timer expiration for user request so if the confirmed users not come back to chan and use command !keep username or msg the bot more then 2 week then they znc account will automatically removed or the bot will notice admin znc to remove the expired znc user account
sorry about my language
thx before